### PR TITLE
Fixing Search Results padding/margins, halving animations

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -75,7 +75,6 @@ a.wiki-nw-link:hover{background-color:var(--button-hover-color);color:#1b1b1b}
 .__sri-time{background-color:var(--time-stamp);color:var(--primary-700);user-select:none}
 .__sri-time.--new{background-color:var(--time-stamp);color:var(--primary-700);user-select:none}
 .sri-group,.search-result,.scene{background-color:#1e2028;border-radius:5px;opacity:0;transform:translateY(20px);animation:fadeInUp .3s ease-out forwards}
-._0_TITLE{padding-left: 1.5rem}
 .__sri-title,.__sri_title_link{transition:all .5s ease}
 .scene{padding:1rem;opacity:0;transform:translateY(20px);animation:fadeInUp .3s ease-out forwards}
 body,html,.mob{background-color:#17191e;font-family:var(--font-lufga),system-ui}

--- a/custom.css
+++ b/custom.css
@@ -37,7 +37,7 @@ a.wiki-nw-link:hover{background-color:var(--button-hover-color);color:#1b1b1b}
 .result-comments .comment:hover{background-color:var(--button-hover-color)}
 .top_podcast_item{width:130px;background-color:#1e2028;padding:10px;border-radius:12px}
 .top_podcast_item:hover{text-decoration:none}
-.__sri-url-box{margin-bottom: 10px;background-color:#17191e;border-radius:5px;padding:8px}
+.__sri-url-box{margin-bottom:10px;background-color:#17191e;border-radius:5px;padding:8px}
 .videoResultItem{background-color:#1e2028}
 .auto_suggestions .auto_item{transition:all .5s ease}
 .auto_suggestions .auto_item.highlighted {background-color:var(--primary-70)}
@@ -45,11 +45,11 @@ a.wiki-nw-link:hover{background-color:var(--button-hover-color);color:#1b1b1b}
 .videoResultItem .videoResultRight .videoResultInfo .videoPublished .videoPublishedDate:hover{background-color:rgba(150,190,250,0.8);color:#1b1b1b}
 .videoResultItem .videoResultRight .videoResultInfo .videoPublishedDate,.videoResultItem .videoResultRight .videoResultInfo .videoViewsCount{background-color:var(--time-stamp);color:var(--primary-700);border-radius:5px;padding:0 6px;transition:background-color .3s ease,color .3s ease;user-select:none}
 .videoResultItem .videoResultRight .videoResultInfo .videoPublishedDate:hover,.videoResultItem .videoResultRight .videoResultInfo .videoViewsCount:hover{background-color:rgba(150,190,250,0.8);color:#1b1b1b}
-.newsResultItem{background-color:#1e2028;border-radius:12px;padding:1.2rem 22px .7rem 18px;opacity:0;transform:translateY(20px);animation:fadeInUp .6s ease-out forwards}
+.newsResultItem{background-color:#1e2028;border-radius:12px;padding:1.2rem 22px .7rem 18px;opacity:0;transform:translateY(20px);animation:fadeInUp .3s ease-out forwards}
 .newsResultItem:first-child{padding-top:1.2rem}
 .newsResultItem .newsResultTime{background-color:var(--time-stamp);color:var(--primary-700);border-radius:5px;padding:0 6px;user-select:none;transition:background-color .3s ease,color .3s ease}
 .newsResultItem .newsResultTime:hover{background-color:rgba(150,190,250,0.8);color:#1b1b1b}
-.podcast_result{background-color:#1e2028;border-radius:12px;padding:1.2rem 22px .7rem 18px;opacity:0;transform:translateY(20px);animation:fadeInUp .6s ease-out forwards}
+.podcast_result{background-color:#1e2028;border-radius:12px;padding:1.2rem 22px .7rem 18px;opacity:0;transform:translateY(20px);animation:fadeInUp .3s ease-out forwards}
 .podcast_result .body .thumbnail img{transition:box-shadow .5s ease}
 .podcast_result .body .thumbnail img:hover{box-shadow:0 8px 15px rgba(0,0,0,0.2)}
 .podcast_result .body{margin-top:0}
@@ -69,19 +69,19 @@ a.wiki-nw-link:hover{background-color:var(--button-hover-color);color:#1b1b1b}
 .app-box-center{margin-top:1rem}
 .read-more-inline{background-color:var(--button-color);color:#1b1b1b;border-radius:10px;padding:2px 8px}
 .read-more-inline:hover{background-color:var(--button-hover-color);color:#1b1b1b}
-.read-more-inline svg{color:#1b1b1b;transition:all .6s ease}
+.read-more-inline svg{color:#1b1b1b;transition:all .3s ease}
 .read-more-inline:hover svg{color:#1b1b1b;transform:translateX(5px)}
 ._0_results_summary_text{color:#b3b7bb}
 .__sri-time{background-color:var(--time-stamp);color:var(--primary-700);user-select:none}
 .__sri-time.--new{background-color:var(--time-stamp);color:var(--primary-700);user-select:none}
-.sri-group,.search-result,.scene{background-color:#1e2028;border-radius:5px;opacity:0;transform:translateY(20px);animation:fadeInUp .6s ease-out forwards}
+.sri-group,.search-result,.scene{background-color:#1e2028;border-radius:5px;opacity:0;transform:translateY(20px);animation:fadeInUp .3s ease-out forwards}
 ._0_TITLE{padding-left: 1.5rem}
 .__sri-title,.__sri_title_link{transition:all .5s ease}
-.scene{padding:1rem;opacity:0;transform:translateY(20px);animation:fadeInUp .6s ease-out forwards}
+.scene{padding:1rem;opacity:0;transform:translateY(20px);animation:fadeInUp .3s ease-out forwards}
 body,html,.mob{background-color:#17191e;font-family:var(--font-lufga),system-ui}
-.search-result{padding:1.2rem .8rem .6rem .8rem;opacity:0;transform:translateY(20px);animation:fadeInUp .6s ease-out forwards}
+.search-result{padding:1.2rem .8rem .6rem .8rem;opacity:0;transform:translateY(20px);animation:fadeInUp .3s ease-out forwards}
 @keyframes fadeInUp{to{opacity:1;transform:translateY(0)}}
-.widgetContent{background-color:#1e2028;border-radius:12px;padding:1.2rem 22px .7rem 18px;opacity:0;transform:translateY(20px);animation:fadeInUp .6s ease-out forwards}
+.widgetContent{background-color:#1e2028;border-radius:12px;padding:1.2rem 22px .7rem 18px;opacity:0;transform:translateY(20px);animation:fadeInUp .3s ease-out forwards}
 .serp-nav .nav_item{position:relative}
 .serp-nav .nav_item:after{content:"";display:block;position:absolute;bottom:0;left:0;width:100%;height:3px;background-color:var(--nav_n_se_line);transform:scaleY(0);transform-origin:bottom;transition:transform .3s ease,box-shadow .3s ease;border-top-left-radius:5px;border-top-right-radius:5px}
 .serp-nav .nav_item:hover:after{transform:scaleY(1)}
@@ -95,7 +95,7 @@ body,html,.mob{background-color:#17191e;font-family:var(--font-lufga),system-ui}
 .results_summary_text_box:has(#qa_show_more:not(:checked)) .smw::before{background:linear-gradient(transparent,#1e2028)}
 ._0_summarize_link{background-color:var(--button-color);max-width:max-content;margin-bottom:10px;margin-top:3px;border-radius:10px!important;padding:5px 10px}
 ._0_summarize_link:hover{background-color:var(--button-hover-color);box-shadow:0 8px 15px rgba(0,0,0,0.2);transition:all .5s ease}
-._0_summarize_link svg{transition:all .6s ease!important}
+._0_summarize_link svg{transition:all .3s ease!important}
 ._0_summarize_link:hover .ic svg{transform:translateX(5px)!important}
 ._0_summarize_link,._0_summarize_link a{color:#232325!important}
 .top-content .top-content ._0_provider-content{display:none!important}
@@ -112,11 +112,11 @@ body,html,.mob{background-color:#17191e;font-family:var(--font-lufga),system-ui}
 .wolfram-answer{background-color:#1e2028;margin-bottom:25px;border-radius:10px;padding-right:10px;padding-left:10px}
 ._0_discuss_document_btn{background-color:var(--button-color);color:#1b1b1b;border-radius:10px;padding:2px 8px;max-width:max-content;position:relative;margin-top:1rem}
 ._0_discuss_document_btn:hover{background-color:var(--button-hover-color);color:#1b1b1b}
-._0_discuss_document_btn svg{transition:all .6s ease}
+._0_discuss_document_btn svg{transition:all .3s ease}
 ._0_discuss_document_btn:hover svg{transform:translateX(5px)}
 .smw{background-color:var(--button-color);color:#1b1b1b;border-radius:10px;padding:2px 8px;max-width:max-content;position:relative;margin:10px auto 0;user-select:none}
 .smw:hover{background-color:var(--button-hover-color);color:#1b1b1b}
-.smw svg{transition:all .6s ease}
+.smw svg{transition:all .3s ease}
 .smw:hover svg{transform:translateX(3px)}
 .results_summary_text_box:has(#qa_show_more:not(:checked)) .smw::before{background:linear-gradient(transparent,#1e2028)}
 .ks-tooltip-body{background-color:var(--k-tooltip-text);color:#FDFDFD}
@@ -134,10 +134,10 @@ body,html,.mob{background-color:#17191e;font-family:var(--font-lufga),system-ui}
 .inlineHeader{transition:all .5s ease}
 .ranked-c-adjust-info-icon:not(.new-tooltip) .k-tooltip:after, .tooltip-trigger:not(.new-tooltip) .k-tooltip:after {border-top: 8px solid var(--secondary);}
 .auto_suggestions_lenses_edit_box:hover {background-color: var(--sri-hover-color);}
-.top_podcast_item {width: 130px;background-color: #1e2028;padding: 10px;border-radius: 12px;}
+.top_podcast_item {width: 130px;background-color: #1e2028;padding:10px;border-radius:12px;}
 .widget-time-ago {background-color: rgba(150, 190, 250, 0.8);color: #1b1b1b;user-select: none;border-radius: 5px;display: inline-block;padding: 0 6px;margin-bottom: auto;margin-top: auto;}
-.podcast_result {background-color: #1e2028;border-radius: 12px;padding-top: 1.2rem;padding-right: 22px;padding-bottom: 0.7rem;padding-left: 18px;opacity: 0;transform: translateY(20px);animation: fadeInUp 0.6s ease-out forwards;}
-.scene {padding: 1rem;opacity: 0; transform: translateY(20px); animation: fadeInUp 0.6s ease-out forwards;}
+.podcast_result {background-color: #1e2028;border-radius: 12px;padding-top: 1.2rem;padding-right: 22px;padding-bottom: 0.7rem;padding-left: 18px;opacity: 0;transform: translateY(20px);animation: fadeInUp 0.3s ease-out forwards;}
+.scene {padding: 1rem;opacity: 0; transform: translateY(20px); animation: fadeInUp 0.3s ease-out forwards;}
 @keyframes fadeInUp {to{opacity: 1;transform: translateY(0);}}
 ._0_queryInfo{display: none;}
 ._0_results_summary_link_to_IA a {color:var(--primary-700);}

--- a/custom.css
+++ b/custom.css
@@ -37,7 +37,7 @@ a.wiki-nw-link:hover{background-color:var(--button-hover-color);color:#1b1b1b}
 .result-comments .comment:hover{background-color:var(--button-hover-color)}
 .top_podcast_item{width:130px;background-color:#1e2028;padding:10px;border-radius:12px}
 .top_podcast_item:hover{text-decoration:none}
-.__sri-url-box{margin-bottom:5px;background-color:#17191e;border-radius:5px;padding:8px}
+.__sri-url-box{margin-bottom: 10px;background-color:#17191e;border-radius:5px;padding:8px}
 .videoResultItem{background-color:#1e2028}
 .auto_suggestions .auto_item{transition:all .5s ease}
 .auto_suggestions .auto_item.highlighted {background-color:var(--primary-70)}
@@ -61,7 +61,7 @@ a.wiki-nw-link:hover{background-color:var(--button-hover-color);color:#1b1b1b}
 .widget-time-ago{background-color:rgba(150,190,250,0.8);color:#1b1b1b;user-select:none;border-radius:5px;display:inline-block;padding:0 6px;margin-bottom:auto;margin-top:auto}
 .app-header.app-content-box{position:sticky;top:0;z-index:114;background:rgba(26,28,35,0.2);border-bottom-left-radius:16px;border-bottom-right-radius:16px;box-shadow:0 2px 15px rgba(0,0,0,.7);backdrop-filter:blur(5px);-webkit-backdrop-filter:blur(5px);border:1px solid rgba(35,35,37,0.3)}
 .quick-settings{background:rgba(32,33,36,0.6);border-bottom-left-radius:16px;border-top-left-radius:16px;box-shadow:0 7px 10px #1a1c23;backdrop-filter:blur(5px);-webkit-backdrop-filter:blur(5px);border:2px solid rgba(35,35,37,0.7)}
-.sri-group .sr-group{padding-left:30px!important;padding-bottom:10px}
+.sri-group .sr-group {padding: 10px 10px 20px 30px!important;margin-top:0px}
 .correctedQuery{line-height:2}
 .wikipedia_results{background-color:#28282a}
 .wiki_desc_text{line-height:1.55}
@@ -75,10 +75,11 @@ a.wiki-nw-link:hover{background-color:var(--button-hover-color);color:#1b1b1b}
 .__sri-time{background-color:var(--time-stamp);color:var(--primary-700);user-select:none}
 .__sri-time.--new{background-color:var(--time-stamp);color:var(--primary-700);user-select:none}
 .sri-group,.search-result,.scene{background-color:#1e2028;border-radius:5px;opacity:0;transform:translateY(20px);animation:fadeInUp .6s ease-out forwards}
+._0_TITLE{padding-left: 1.5rem}
 .__sri-title,.__sri_title_link{transition:all .5s ease}
 .scene{padding:1rem;opacity:0;transform:translateY(20px);animation:fadeInUp .6s ease-out forwards}
 body,html,.mob{background-color:#17191e;font-family:var(--font-lufga),system-ui}
-.search-result{padding:1.2rem 22px .7rem 18px;opacity:0;transform:translateY(20px);animation:fadeInUp .6s ease-out forwards}
+.search-result{padding:1.2rem .8rem .6rem .8rem;opacity:0;transform:translateY(20px);animation:fadeInUp .6s ease-out forwards}
 @keyframes fadeInUp{to{opacity:1;transform:translateY(0)}}
 .widgetContent{background-color:#1e2028;border-radius:12px;padding:1.2rem 22px .7rem 18px;opacity:0;transform:translateY(20px);animation:fadeInUp .6s ease-out forwards}
 .serp-nav .nav_item{position:relative}


### PR DESCRIPTION
Adjusted values to create more even/consistent spacing for standard search results on the page. 
Adjusted values for title padding to center title + favicon, not just title. Removed unused padding for favicon in sub-results.
Tested live and seems to respond as expected when font/zoom changes. 
Halved animation value/doubled speed on most animations, personally I think it makes it feel snappier without removing them entirely. 

Outstanding issue, still investigating: nav menu item "Lens" on hover is misaligned/miscolored, mis-sized for space.